### PR TITLE
Addresses Issue: Separate path from file name in glossary/import and export #71

### DIFF
--- a/pyegeria/commands/cat/glossary_actions.py
+++ b/pyegeria/commands/cat/glossary_actions.py
@@ -48,6 +48,7 @@ EGERIA_USER_PASSWORD = os.environ.get("EGERIA_USER_PASSWORD", "secret")
 EGERIA_WIDTH = os.environ.get("EGERIA_WIDTH", 200)
 EGERIA_JUPYTER = os.environ.get("EGERIA_JUPYTER", False)
 EGERIA_HOME_GLOSSARY_GUID = os.environ.get("EGERIA_HOME_GLOSSARY_GUID", None)
+EGERIA_GLOSSARY_PATH = os.environ.get("EGERIA_GLOSSARY_PATH", None)
 
 
 @click.command("create-glossary")
@@ -265,8 +266,11 @@ def delete_term(server, url, userid, password, timeout, term_guid):
 
 
 @click.command("import-terms")
-@click.option("--glossary-name", help="Name of Glossary", required=True)
-@click.option("--file-name", help="Path of CSV file", required=True)
+@click.option("--glossary_name", help="Name of Glossary", required=True)
+@click.option("--file_name", help="Path of CSV file", required=True)
+@click.option(
+    "--file_path", help="Path of CSV file", default=EGERIA_GLOSSARY_PATH, required=False
+)
 @click.option(
     "--verbose",
     is_flag=True,
@@ -288,6 +292,7 @@ def delete_term(server, url, userid, password, timeout, term_guid):
 @click.option("--timeout", default=60, help="Number of seconds to wait")
 def import_terms(
     glossary_name: str,
+    file_path: str,
     file_name: str,
     verbose: bool,
     upsert: bool,
@@ -302,7 +307,11 @@ def import_terms(
     token = m_client.create_egeria_bearer_token()
     try:
         result = m_client.load_terms_from_file(
-            glossary_name, file_name, upsert=upsert, verbose=verbose
+            glossary_name,
+            file_name,
+            file_path=file_path,
+            upsert=upsert,
+            verbose=verbose,
         )
 
         click.echo(
@@ -319,12 +328,15 @@ def import_terms(
 
 @click.command("export-terms")
 @click.option(
-    "--glossary-guid",
+    "--glossary_guid",
     default=EGERIA_HOME_GLOSSARY_GUID,
     help="GUID of Glossary to export",
     required=True,
 )
-@click.option("--file-name", help="Path of CSV file", required=True)
+@click.option("--file_name", help="Path of CSV file", required=True)
+@click.option(
+    "--file_path", help="Path of CSV file", default=EGERIA_GLOSSARY_PATH, required=False
+)
 @click.option("--server", default=EGERIA_VIEW_SERVER, help="Egeria view server to use")
 @click.option(
     "--url", default=EGERIA_VIEW_SERVER_URL, help="URL of Egeria platform to connect to"
@@ -332,12 +344,14 @@ def import_terms(
 @click.option("--userid", default=EGERIA_USER, help="Egeria user")
 @click.option("--password", default=EGERIA_USER_PASSWORD, help="Egeria user password")
 @click.option("--timeout", default=60, help="Number of seconds to wait")
-def export_terms(glossary_guid: str, file_name, server, url, userid, password, timeout):
+def export_terms(
+    glossary_guid: str, file_name, file_path, server, url, userid, password, timeout
+):
     """Export the glossary specified"""
     m_client = EgeriaTech(server, url, user_id=userid, user_pwd=password)
     token = m_client.create_egeria_bearer_token()
     try:
-        result = m_client.export_glossary_to_csv(glossary_guid, file_name)
+        result = m_client.export_glossary_to_csv(glossary_guid, file_name, file_path)
 
         click.echo(
             f"Exported {result} terms  from glossary: {glossary_guid} into {file_name}"

--- a/pyegeria/commands/cli/egeria.py
+++ b/pyegeria/commands/cli/egeria.py
@@ -879,7 +879,7 @@ def glossary_group(ctx):
 )
 @click.option(
     "--glossary-guid",
-    default=None,
+    default=os.environ.get("EGERIA_HOME_GLOSSARY_GUID", None),
     help="Optionally restrict search to glossary with the specified guid",
 )
 @click.option(

--- a/pyegeria/commands/cli/egeria_cat.py
+++ b/pyegeria/commands/cli/egeria_cat.py
@@ -129,7 +129,8 @@ from pyegeria.commands.tech.list_asset_types import display_asset_types
 )
 @click.option(
     "--width",
-    default=os.environ.get("EGERIA_WIDTH", "200"),
+    default=os.environ.get("EGERIA_WIDTH", 200),
+    type=int,
     help="Screen width, in characters, to use",
 )
 @click.option(

--- a/pyegeria/commands/cli/egeria_cat.py
+++ b/pyegeria/commands/cli/egeria_cat.py
@@ -311,7 +311,7 @@ def glossary_group(ctx):
 )
 @click.option(
     "--glossary-guid",
-    default=os.environ.get("EGERIA_HOME_GLOSSARY_GUID"),
+    default=os.environ.get("EGERIA_HOME_GLOSSARY_GUID", None),
     help="Optionally restrict search to glossary with the specified guid",
 )
 @click.option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyegeria"
-version = "5.2.0.42.4"
+version = "5.2.0.42.5"
 license = 'Apache 2.0'
 authors = ["Dan Wolfson <dan.wolfson@pdr-associates.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyegeria"
-version = "5.2.0.42.5"
+version = "5.2.0.42.8"
 license = 'Apache 2.0'
 authors = ["Dan Wolfson <dan.wolfson@pdr-associates.com>"]
 readme = "README.md"

--- a/tests/test_glossary_manager_omvs.py
+++ b/tests/test_glossary_manager_omvs.py
@@ -585,8 +585,9 @@ class TestGlossaryManager:
             )
             token = g_client.create_egeria_bearer_token(self.good_user_3, "secret")
             glossary = "example"
-            file_name = "/Users/dwolfson/localGit/egeria-v5-1/egeria-workspaces/exchange/loading-bay/glossary/upsert-example.om-terms"
-            response = g_client.load_terms_from_file(glossary, file_name, True)
+            file_path = "/Users/dwolfson/localGit/egeria-v5-1/egeria-workspaces/exchange/loading-bay/glossary"
+            file_name = "pets.om-terms"
+            response = g_client.load_terms_from_file(glossary, file_name, file_path)
             print(f"type is {type(response)}")
             if type(response) is list:
                 print("\n\n" + json.dumps(response, indent=4))
@@ -598,6 +599,7 @@ class TestGlossaryManager:
             InvalidParameterException,
             PropertyServerException,
             UserNotAuthorizedException,
+            FileNotFoundError,
         ) as e:
             print_exception_response(e)
             assert False, "Invalid request"


### PR DESCRIPTION
Updated glossary import/export to optionally provide a separate directory path and added EGERIA_GLOSSARY_PATH environment variable; update hey_egeria to use.
