### PR TITLE
fix(mcp): migrate mcp_server.py to mcp 2.0.0's MCPServer, fix stale t…

### DIFF
--- a/pyegeria/core/mcp_server.py
+++ b/pyegeria/core/mcp_server.py
@@ -10,7 +10,7 @@ from loguru import logger
 
 from typing import Any, Dict, Optional, Literal
 
-from mcp.server.fastmcp.exceptions import ValidationError
+from pydantic_core import ValidationError
 
 from pyegeria.egeria_tech_client import EgeriaTech
 from pyegeria.core._exceptions import print_validation_error
@@ -21,7 +21,7 @@ nest_asyncio.apply()
 
 try:
     # We use Optional[] and List[] types, so we import them.
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
     from pyegeria.core.mcp_adapter import (
         list_reports,
         describe_report,
@@ -75,7 +75,7 @@ def main() -> None:
         logger.debug(f"Exception occurred: {str(e)}")
         raise
 
-    srv = FastMCP(name="pyegeria-mcp")
+    srv = MCPServer(name="pyegeria-mcp")
     print("Starting MCP server...", file=sys.stderr)
 
     # list_reports tool (formerly list_format_sets)
@@ -95,7 +95,7 @@ def main() -> None:
     @srv.tool(name="describe_report")
     def describe_report_tool(name: str, output_type: Literal["DICT", "JSON", "MARKDOWN"] = "DICT") -> Dict[str, Any]:
         """Returns the schema and details for a specified report."""
-        # FastMCP handles validation of 'name' and 'output_type' types automatically.
+        # MCPServer handles validation of 'name' and 'output_type' types automatically.
         effective_output_type = "REPORT" if output_type == "MARKDOWN" else ("DICT" if output_type == "JSON" else output_type)
 
         logger.debug(f"Describing report: {name} with output type: {effective_output_type}")
@@ -126,7 +126,7 @@ def main() -> None:
 
         """Run a report with the specified parameters."""
         print("DEBUG: Running report...", file=sys.stderr)
-        # 1. Automatic Validation: FastMCP/Pydantic ensures types are correct.
+        # 1. Automatic Validation: MCPServer/Pydantic ensures types are correct.
 
         # 2. Manual Validation (for specific values like output_format)
         # "MARKDOWN" is a friendly alias for the executor's internal "REPORT".
@@ -167,7 +167,7 @@ def main() -> None:
             # GLOBAL_EGERIA_CLIENT (created in the server's startup loop) caused
             # intermittent CLIENT_ERROR_400 ("unable to connect") because its
             # httpx async client is bound to a different loop than the one
-            # FastMCP runs tool handlers in. A per-call client (mirroring
+            # MCPServer runs tool handlers in. A per-call client (mirroring
             # exec_report_spec / the CLI) is reliable.
             from pyegeria.core.config import settings as _settings
             _user = _settings.User_Profile.user_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 
 [project.scripts]
-    pyegeria-mcp = "pyegeria.mcp_server:main"
+    pyegeria-mcp = "pyegeria.core.mcp_server:main"
     run_report = "commands.cat.run_report:main"
     run_report_orig = "commands.cat.run_report_orig:main"
     my_reports = "commands.cat.my_reports:start_exp2"

--- a/tests/functional-tests/test_mcp_adapter.py
+++ b/tests/functional-tests/test_mcp_adapter.py
@@ -1,29 +1,35 @@
-import types
 import pytest
 
 
-def test_list_tools_smoke():
-    from pyegeria.mcp.mcp_adapter import list_mcp_tools
+def test_list_reports_smoke():
+    from pyegeria.core.mcp_adapter import list_reports
 
-    out = list_mcp_tools()
+    out = list_reports()
     assert isinstance(out, dict)
-    assert "formatSets" in out
-    assert isinstance(out["formatSets"], list)
+    assert len(out) > 0
+    # Each entry is {name: {description, target_type, required_params, optional_params}}
+    name, meta = next(iter(out.items()))
+    assert isinstance(name, str)
+    assert isinstance(meta, dict)
+    assert "description" in meta
+    assert "target_type" in meta
+    assert "required_params" in meta
+    assert "optional_params" in meta
 
 
-def test_describe_known_set():
-    from pyegeria.mcp.mcp_adapter import describe_mcp_tool
+def test_describe_known_report():
+    from pyegeria.core.mcp_adapter import describe_report
 
-    # Choose a commonly defined format set present in _output_formats.py
-    meta = describe_mcp_tool("Digital-Products", outputType="ANY")
+    # Choose a commonly defined report spec present in base_report_formats.py
+    meta = describe_report("Digital-Products", "ANY")
     assert isinstance(meta, dict)
     assert meta.get("target_type") in {"DigitalProduct", "Collection", "Referenceable"}
     assert "action" in meta
 
 
-def test_run_tool_monkeypatched(monkeypatch):
+def test_run_report_monkeypatched(monkeypatch):
     # Monkeypatch the executor used by mcp_adapter so there is no network call
-    import pyegeria.mcp.mcp_adapter as m
+    import pyegeria.core.mcp_adapter as m
 
     fake_result = {"kind": "json", "data": [{"guid": "123", "display_name": "X"}]}
 
@@ -35,5 +41,14 @@ def test_run_tool_monkeypatched(monkeypatch):
 
     monkeypatch.setattr(m, "exec_report_spec", fake_exec)
 
-    out = m.run_mcp_tool(formatSet="Digital-Products", outputFormat="DICT", params={"search_string": "*"})
+    out = m.run_report(report="Digital-Products", params={"search_string": "*"})
     assert out == fake_result
+
+
+def test_run_find_report_specs_wildcards():
+    from pyegeria.core.mcp_adapter import run_find_report_specs
+
+    # "*" is the documented "skip this filter" sentinel for each argument
+    out = run_find_report_specs(perspective="*", question="*", report_spec="*")
+    assert isinstance(out, dict)
+    assert "Matching Report Specs" in out


### PR DESCRIPTION
…est/entry-point

mcp 2.0.0 renamed FastMCP -> MCPServer and moved mcp.server.fastmcp -> mcp.server.mcpserver with no compat shim (the old module path is gone entirely). Migrated pyegeria/core/mcp_server.py accordingly, verified against a real mcp 2.0.0 install (isolated probe venv + this repo's dev venv): server construction, sync/async tool registration, and an actual tool call all work; the wire response clients read (CallToolResult.content) is unchanged, structured_content is additive only.

Also fixed two unrelated bugs found while in this file:
- The except ValidationError clause imported FastMCP's own unrelated exception class under that name, not pydantic's -- it could never have caught what it was written to catch. Corrected to `from pydantic_core import ValidationError`, matching what print_validation_error() actually expects.
- pyproject.toml's `pyegeria-mcp` console-script entry pointed at the nonexistent `pyegeria.mcp_server` instead of `pyegeria.core.mcp_server` -- the command was completely broken before this fix.

tests/functional-tests/test_mcp_adapter.py was testing a different, no-longer-existing adapter API (pyegeria.mcp.mcp_adapter with list_mcp_tools/describe_mcp_tool/run_mcp_tool). Rewritten against the real, current pyegeria.core.mcp_adapter (list_reports/describe_report/ run_report/run_find_report_specs), verified against live data.